### PR TITLE
Fixes support for dominos

### DIFF
--- a/ClassicSpellActivations.lua
+++ b/ClassicSpellActivations.lua
@@ -128,6 +128,15 @@ function f:PLAYER_LOGIN()
                 ns.LAB_UpdateOverlayGlow(self)
             end)
         end
+		
+		local dominosPrefix = "DominosActionButton"
+		for i = 1, 72 do
+			local btnName = dominosPrefix..i
+			local btn = _G[btnName]
+			if btn then
+				self:RegisterForActivations(btn)
+			end
+		end
 
         -- if Neuron then
         --     for i,bar in ipairs(Neuron.BARIndex) do


### PR DESCRIPTION
This is the last PR I have in mind. Dominos support at the moment is a but buggy, and this is probably due to the fact that Dominos is not consistent with the naming of their ActionButtons. As you can see in the next picture, the execute button is called ActionButton2 as expected by the addon.
![image](https://user-images.githubusercontent.com/27913259/119157069-14ddd180-ba55-11eb-9bf1-d2f703a844b1.png)

However, some of the other Dominos action buttons have a different name, as it's depicted by the following image:
![image](https://user-images.githubusercontent.com/27913259/119157388-6dad6a00-ba55-11eb-8d7c-6e31cdcce203.png)

The Dominos Action Buttons name format can be seen here https://github.com/tullamods/Dominos/blob/27ccef5e1b7d418c031c2d4fca9415d9831a25bb/Dominos/bars/actionButtons.lua#L8

If the user is not using Dominos, the code sould work anyway because we check if the button exists before registering for activation of the glow effect.



